### PR TITLE
Ensure invite delay respects interruptions

### DIFF
--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
@@ -554,6 +554,7 @@ public class FriendManager {
             return;
         }
 
+        boolean interrupted = false;
         try {
             CreateHandleRequest createHandleContent = new CreateHandleRequest(
                 1,
@@ -576,8 +577,22 @@ public class FriendManager {
 
             HttpResponse<String> inviteResponse = httpClient.send(sendInvite, HttpResponse.BodyHandlers.ofString());
             logger.debug(inviteResponse.body());
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            interrupted = true;
+            Thread.currentThread().interrupt();
+            logger.warn("Invite sending interrupted for " + xuid + ": " + e.getMessage());
+        } catch (IOException e) {
             logger.error("Failed to send invite to " + xuid + ": " + e.getMessage());
+        } finally {
+            if (!interrupted) {
+                logger.debug("Invite attempt finished, waiting 1 second before the next attempt");
+                try {
+                    TimeUnit.SECONDS.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.warn("Invite delay interrupted for " + xuid + ": " + e.getMessage());
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure FriendManager waits one second after each invite attempt while skipping the delay if the thread was interrupted
- add debug logging to show when the invite delay starts and handle interruption during the delay

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d32f2eefc88321a00f188d244c228b